### PR TITLE
Update ngrok installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ I've setup a [sample Rails 6 app](https://github.com/MikeRogers0/puma-ngrok-tunn
 
 Make sure you have installed ngrok on your machine:
 
-    $ brew install ngrok
+    $ brew tap caskroom/cask
+    $ brew cask install ngrok 
 
 Add this line to your application's Gemfile:
 


### PR DESCRIPTION
Update instructions for installing ngrok to reflect that it is a cask, not a formula.

The current instructions will yield:

```sh
➜ brew install ngrok
Error: No available formula with the name "ngrok"
Found a cask named "ngrok" instead.
```

What we want is (I already had it installed):

```sh
➜ brew tap caskroom/cask && brew cask install ngrok
==> Tapping caskroom/cask
Cloning into '/usr/local/Homebrew/Library/Taps/caskroom/homebrew-cask'...
remote: Enumerating objects: 4118, done.
remote: Counting objects: 100% (4118/4118), done.
remote: Compressing objects: 100% (4106/4106), done.
remote: Total 4118 (delta 27), reused 826 (delta 10), pack-reused 0
Receiving objects: 100% (4118/4118), 1.33 MiB | 13.47 MiB/s, done.
Resolving deltas: 100% (27/27), done.
Tapped 1 command and 4011 casks (4,124 files, 4.2MB).

Warning: Cask 'ngrok' is already installed.

To re-install ngrok, run:
  brew cask reinstall ngrok
```

Separated the commands in this PR vs chaining them so it is easier for newcomers. 😁 