### PR TITLE
Handling offline exception when connecting to Ngrok

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.1.6 (In Development)
 
+* [Handling offline exception when connecting to Ngrok](https://github.com/MikeRogers0/puma-ngrok-tunnel/pull/13)
 * I'd love to improve how I've tested this gem.
 
 ## 0.1.5

--- a/lib/puma/plugin/ngrok_tunnel.rb
+++ b/lib/puma/plugin/ngrok_tunnel.rb
@@ -16,8 +16,10 @@ Puma::Plugin.create do
   def ngrok_start!
     begin
       puts '[puma-ngrok-tunnel] Tunneling at: ' + Ngrok::Tunnel.start(options)
+    rescue Ngrok::FetchUrlError => e
+      puts '[puma-ngrok-tunnel] Unable connect to ngrok server (You might be offline): ' + e.to_s
     rescue Ngrok::Error => e
-      puts '[puma-ngrok-tunnel] Unable to start tunnel: ' + e.to_s
+      puts '[puma-ngrok-tunnel] Unable to start tunnel (You might have another active connection): ' + e.to_s
     end
   end
 


### PR DESCRIPTION
If you're offline ngrok can't setup the tunnel, this suppresses the error that will occour.