### PR TITLE
Adding funding_uri & other metadata

### DIFF
--- a/puma-ngrok-tunnel.gemspec
+++ b/puma-ngrok-tunnel.gemspec
@@ -13,6 +13,15 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/mikerogers0/puma-ngrok-tunnel'
   spec.license       = 'MIT'
 
+  spec.metadata = {
+    "bug_tracker_uri" => "#{spec.homepage}/issues",
+    "changelog_uri" => "#{spec.homepage}/blob/master/CHANGELOG.md",
+    "documentation_uri" => spec.homepage,
+    "homepage_uri" => spec.homepage,
+    "source_code_uri" => spec.homepage,
+    "funding_uri" => 'https://www.buymeacoffee.com/MikeRogers0'
+  }
+
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path(__dir__)) do

--- a/puma-ngrok-tunnel.gemspec
+++ b/puma-ngrok-tunnel.gemspec
@@ -14,12 +14,12 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.metadata = {
-    "bug_tracker_uri" => "#{spec.homepage}/issues",
-    "changelog_uri" => "#{spec.homepage}/blob/master/CHANGELOG.md",
-    "documentation_uri" => spec.homepage,
-    "homepage_uri" => spec.homepage,
-    "source_code_uri" => spec.homepage,
-    "funding_uri" => 'https://www.buymeacoffee.com/MikeRogers0'
+    'bug_tracker_uri' => "#{spec.homepage}/issues",
+    'changelog_uri' => "#{spec.homepage}/blob/master/CHANGELOG.md",
+    'documentation_uri' => spec.homepage,
+    'homepage_uri' => spec.homepage,
+    'source_code_uri' => spec.homepage,
+    'funding_uri' => 'https://www.buymeacoffee.com/MikeRogers0'
   }
 
   # Specify which files should be added to the gem when it is released.


### PR DESCRIPTION
Ruby gems added support for `funding_uri` ( https://github.com/rubygems/rubygems/pull/3390 ), so adding that in.