### PR TITLE
Only use Dependabot to check for Ruby/GH Action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,20 +8,8 @@ updates:
     schedule:
       interval: "daily"
 
-  # Maintain dependencies for npm
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-
   # Maintain dependencies for Bundler
   - package-ecosystem: "bundler"
-    directory: "/"
-    schedule:
-      interval: "daily"
-
-  # Maintain dependencies for Docker
-  - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
I copied a fairly general dependabot setup & left some boilerplate in there. Tidying that right up :)