### PR TITLE
Using standalone rubocop in GitHub Action

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -25,6 +25,6 @@ jobs:
     - name: Install gems
       run: |
         bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
+        gem install rubocop
     - name: Run RuboCop
-      run: bundle exec rubocop --parallel
+      run: rubocop --parallel

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,12 +1,13 @@
 name: RuboCop
 
+
 on:
   push:
-    branches:
+    branches-ignore:
       - master
-  pull_request:
+
 jobs:
-  build:
+  rubocop:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Running via bundle was _fine_, but it's a tad quicker to just install the latest rubocop.