### PR TITLE
Being less specific in the version I track for GitHub Action

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -17,8 +17,8 @@ jobs:
     - name: Set up Ruby 2.7
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.7.x
-    - uses: actions/cache@v2.1.2
+        ruby-version: 2.7.2
+    - uses: actions/cache@v2
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}


### PR DESCRIPTION
I'm rubbish at keeping atop of Dependabot, so making the versions less specific.