### PR TITLE
Locking changelog generator to 1.15.2

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -28,7 +28,7 @@ jobs:
           ${{ runner.os }}-changelog-gem-
     - name: Create local changes
       run: |
-        gem install github_changelog_generator
+        gem install github_changelog_generator -v "1.15.2"
         github_changelog_generator -u ${{ github.repository_owner }} -p ${{ github.event.repository.name }} --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
     - name: Commit files
       run: |


### PR DESCRIPTION
There is currently a problem with `github_changelog_generator`, so locking to previous version while I look into it.

```bash
/opt/hostedtoolcache/Ruby/3.0.0/x64/lib/ruby/gems/3.0.0/gems/octokit-4.20.0/lib/octokit/client/issues.rb:30:in `list_issues': wrong number of arguments (given 3, expected 0..2) (ArgumentError)
	from /opt/hostedtoolcache/Ruby/3.0.0/x64/lib/ruby/gems/3.0.0/gems/github_changelog_generator-1.16.1/lib/github_changelog_generator/octo_fetcher.rb:415:in `block in iterate_pages'
	from /opt/hostedtoolcache/Ruby/3.0.0/x64/lib/ruby/gems/3.0.0/gems/retriable-3.1.2/lib/retriable.rb:61:in `block in retriable'
	from /opt/hostedtoolcache/Ruby/3.0.0/x64/lib/ruby/gems/3.0.0/gems/retriable-3.1.2/lib/retriable.rb:56:in `times'
	from /opt/hostedtoolcache/Ruby/3.0.0/x64/lib/ruby/gems/3.0.0/gems/retriable-3.1.2/lib/retriable.rb:56:in `retriable'
	from /opt/hostedtoolcache/Ruby/3.0.0/x64/lib/ruby/gems/3.0.0/gems/github_changelog_generator-1.16.1/lib/github_changelog_generator/octo_fetcher.rb:446:in `check_github_response'
	from /opt/hostedtoolcache/Ruby/3.0.0/x64/lib/ruby/gems/3.0.0/gems/github_changelog_generator-1.16.1/lib/github_changelog_generator/octo_fetcher.rb:415:in `iterate_pages'
	from /opt/hostedtoolcache/Ruby/3.0.0/x64/lib/ruby/gems/3.0.0/gems/github_changelog_generator-1.16.1/lib/github_changelog_generator/octo_fetcher.rb:164:in `fetch_closed_issues_and_pr'
	from /opt/hostedtoolcache/Ruby/3.0.0/x64/lib/ruby/gems/3.0.0/gems/github_changelog_generator-1.16.1/lib/github_changelog_generator/generator/generator.rb:144:in `fetch_issues_and_pr'
	from /opt/hostedtoolcache/Ruby/3.0.0/x64/lib/ruby/gems/3.0.0/gems/github_changelog_generator-1.16.1/lib/github_changelog_generator/generator/generator.rb:55:in `block in compound_changelog'
	from /opt/hostedtoolcache/Ruby/3.0.0/x64/lib/ruby/gems/3.0.0/gems/async-1.28.9/lib/async/task.rb:265:in `block in make_fiber'
```